### PR TITLE
fix: remove malformed trailing slashes from documentation comment

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use crate::fuzzy_finder_interface::{FuzzyFinder, SelectionResult};
 ///
 /// # Arguments
 ///
-/// * `debug_mode` - If `true`, sets the logging level to `DEBUG`, otherwise `INFO`.///
+/// * `debug_mode` - If `true`, sets the logging level to `DEBUG`, otherwise `INFO`.
 ///
 /// The main entry point of the application.
 ///


### PR DESCRIPTION
Fixed a malformed rustdoc comment on line 31 of main.rs that had extra '///' at the end of the line. This ensures proper documentation generation and improves code quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)